### PR TITLE
Add combining fwd_flow_delta_bytes rev_flow_delta_bytes into netflow.bytes

### DIFF
--- a/logstash/conf.d/20_filter.logstash.conf
+++ b/logstash/conf.d/20_filter.logstash.conf
@@ -184,6 +184,11 @@ filter {
                 id => "netflow-v9-normalize-bytes-from-in_permanent_bytes"
                 rename => { "[netflow][in_permanent_bytes]" => "[netflow][bytes]" }
             }
+        } 
+            else if [netflow][fwd_flow_delta_bytes] or [netflow][rev_flow_delta_bytes] {
+           ruby {
+                 code => "event.set('[netflow][bytes]',event.get('[netflow][fwd_flow_delta_bytes]').to_i + event.get('[netflow][rev_flow_delta_bytes]').to_i)"
+           }
         }
         if [netflow][bytes] {
             mutate {


### PR DESCRIPTION
Came a cross a situation when our firewall (ASA) after upgrade now sends fwd_flow_delta_bytes  and rev_flow_delta_bytes  and so logstash was not populating netflow.bytes, which is used in all Kibana stuff.
Added to the filter to use these if they are present.
