### PR TITLE
Implement byte and flow time conversions for ASA - Address #22

### DIFF
--- a/logstash/conf.d/20_filter.logstash.conf
+++ b/logstash/conf.d/20_filter.logstash.conf
@@ -210,15 +210,10 @@ filter {
                 id => "netflow-v9-normalize-bytes-from-in_permanent_bytes"
                 rename => { "[netflow][in_permanent_bytes]" => "[netflow][bytes]" }
             }
-        } else if [netflow][rev_flow_delta_bytes] {
-             mutate {
-                id => "netflow-v9-normalize-bytes-from-rev_flow_delta_bytes"
-                rename => { "[netflow][rev_flow_delta_bytes]" => "[netflow][bytes]" }
-            }
-        } else if [netflow][fwd_flow_delta_bytes] {
-             mutate {
-                id => "netflow-v9-normalize-bytes-from-fwd_flow_delta_bytes"
-                rename => { "[netflow][fwd_flow_delta_bytes]" => "[netflow][bytes]" }
+        } else if [netflow][fwd_flow_delta_bytes] or [netflow][rev_flow_delta_bytes] {
+            ruby {
+                id => "netflow-v9-sum-bytes-from-delta_bytes-fields"
+                code => "event.set('[netflow][bytes]',event.get('[netflow][fwd_flow_delta_bytes]').to_i + event.get('[netflow][rev_flow_delta_bytes]').to_i)"
             }
         }
 
@@ -245,7 +240,13 @@ filter {
                 id => "netflow-v9-normalize-packets-from-in_permanent_pkts"
                 rename => { "[netflow][in_permanent_pkts]" => "[netflow][packets]" }
             }
+        } else if [netflow][initiatorPackets] or [netflow][responderPackets] {
+            ruby {
+                id => "netflow-v9-sum-packets-from-initiator_responder_packets-fields"
+                code => "event.set('[netflow][packets]',event.get('[netflow][initiatorPackets]').to_i + event.get('[netflow][responderPackets]').to_i)"
+           }
         }
+
         if [netflow][packets] {
             mutate {
                 id => "netflow-v9-normalize-convert-packets"

--- a/logstash/conf.d/20_filter.logstash.conf
+++ b/logstash/conf.d/20_filter.logstash.conf
@@ -42,6 +42,32 @@ filter {
                 add_field => { "[netflow][ip_version]" => "IPv%{[netflow][ip_protocol_version]}" }
             }
         }
+
+        if [netflow][flow_start_msec] {
+            mutate {
+                id => "netflow-v9-rename-flow-start-time"
+                rename => { "[netflow][flow_start_msec]" => "[netflow][first_switched]" }
+           }
+
+           date {
+                id => "netflow-v9-normalize-flow-start-time"
+                match => ["[netflow][first_switched]", "UNIX_MS"]
+                target => "[netflow][first_switched]"
+           }
+        }
+
+        if [netflow][event_time_msec] {
+            mutate {
+                id => "netflow-v9-rename-flow-event-time"
+                rename => { "[netflow][event_time_msec]" => "[netflow][last_switched]" }
+           }
+
+           date {
+                id => "netflow-v9-normalize-flow-event-time"
+                match => ["[netflow][last_switched]", "UNIX_MS"]
+                target => "[netflow][last_switched]"
+           }
+        }
         
         # Populate fields with IPv4 or IPv6 specific fields.
         if [netflow][ipv4_src_addr] or [netflow][ipv4_dst_addr] or [netflow][ip_protocol_version] == 4 {
@@ -184,7 +210,18 @@ filter {
                 id => "netflow-v9-normalize-bytes-from-in_permanent_bytes"
                 rename => { "[netflow][in_permanent_bytes]" => "[netflow][bytes]" }
             }
+        } else if [netflow][rev_flow_delta_bytes] {
+             mutate {
+                id => "netflow-v9-normalize-bytes-from-rev_flow_delta_bytes"
+                rename => { "[netflow][rev_flow_delta_bytes]" => "[netflow][bytes]" }
+            }
+        } else if [netflow][fwd_flow_delta_bytes] {
+             mutate {
+                id => "netflow-v9-normalize-bytes-from-fwd_flow_delta_bytes"
+                rename => { "[netflow][fwd_flow_delta_bytes]" => "[netflow][bytes]" }
+            }
         }
+
         if [netflow][bytes] {
             mutate {
                 id => "netflow-v9-normalize-convert-bytes"


### PR DESCRIPTION
Convert fields relevant to flow time tracking and byte counts from
Cisco ASA 9.2 v9 to fields understood by the Kibana queries.

Testing:
  Initial test runs on several ASAs, needs wider testing across
multiple versions, ASA/ASDM configs, etc.

Todo:
  There's no *pkt* field in the ASA outputs, determine if metric
can be exposed and collected. Write conversions if data exists.