### PR TITLE
Fix: default value of template path

### DIFF
--- a/logstash/elastiflow/conf.d/30_output_10_single.logstash.conf
+++ b/logstash/elastiflow/conf.d/30_output_10_single.logstash.conf
@@ -26,7 +26,7 @@ output {
     user => "${ELASTIFLOW_ES_USER:elastic}"
     password => "${ELASTIFLOW_ES_PASSWD:changeme}"
     index => "elastiflow-3.2.1-%{+YYYY.MM.dd}"
-    template => "${ELASTIFLOW_TEMPLATE_PATH:/etc/logstash/templates}/elastiflow.template.json"
+    template => "${ELASTIFLOW_TEMPLATE_PATH:/etc/logstash/elastiflow/templates}/elastiflow.template.json"
     template_name => "elastiflow-3.2.1"
     template_overwrite => "true"
   }

--- a/logstash/elastiflow/conf.d/30_output_20_multi.logstash.conf.disabled
+++ b/logstash/elastiflow/conf.d/30_output_20_multi.logstash.conf.disabled
@@ -26,7 +26,7 @@ output {
     user => "${ELASTIFLOW_ES_USER:elastic}"
     password => "${ELASTIFLOW_ES_PASSWD:changeme}"
     index => "elastiflow-3.2.1-%{+YYYY.MM.dd}"
-    template => "${ELASTIFLOW_TEMPLATE_PATH:/etc/logstash/templates}/elastiflow.template.json"
+    template => "${ELASTIFLOW_TEMPLATE_PATH:/etc/logstash/elastiflow/templates}/elastiflow.template.json"
     template_name => "elastiflow-3.2.1"
     template_overwrite => "true"
   }


### PR DESCRIPTION
Failed to start logstash with default configuration.

```
Aug  2 17:00:22 localhost logstash[10085]: [2018-08-02T17:00:22,003][ERROR][logstash.outputs.elasticsearch] Invalid setting for elasticsearch output plugin:
Aug  2 17:00:22 localhost logstash[10085]:   output {
Aug  2 17:00:22 localhost logstash[10085]:     elasticsearch {
Aug  2 17:00:22 localhost logstash[10085]:       # This setting must be a path
Aug  2 17:00:22 localhost logstash[10085]:       # File does not exist or cannot be opened /etc/logstash/templates/elastiflow.template.json
Aug  2 17:00:22 localhost logstash[10085]:       template => "/etc/logstash/templates/elastiflow.template.json"
Aug  2 17:00:22 localhost logstash[10085]:       ...
Aug  2 17:00:22 localhost logstash[10085]:     }
Aug  2 17:00:22 localhost logstash[10085]:   }
```

According to the [document](https://github.com/robcowart/elastiflow#3-copy-the-pipeline-files-to-the-logstash-configuration-path), default template path should be something like `/etc/logstash/elastiflow/templates` not `/etc/logstash/templates`.