### PR TITLE
Typo fix in post_processing

### DIFF
--- a/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
@@ -836,7 +836,7 @@ filter {
             if [flow][src_city] {
               mutate {
                 id => "elastiflow_postproc_srcIsSrv_add_src_autonomous_system"
-                add_field => { "[flow][server_city]]" => "%{[flow][src_city]}" }
+                add_field => { "[flow][server_city]" => "%{[flow][src_city]}" }
               }
             }
             if [flow][src_country] {

--- a/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
@@ -736,7 +736,7 @@ filter {
             if [flow][src_city] {
               mutate {
                 id => "elastiflow_postproc_dstIsSrv_add_src_src_city"
-                add_field => { "[flow][client_city]]" => "%{[flow][src_city]}" }
+                add_field => { "[flow][client_city]" => "%{[flow][src_city]}" }
               }
             }
             if [flow][src_country] {
@@ -793,7 +793,7 @@ filter {
             if [flow][dst_city] {
               mutate {
                 id => "elastiflow_postproc_srcIsSrv_add_dst_city"
-                add_field => { "[flow][client_city]]" => "%{[flow][dst_city]}" }
+                add_field => { "[flow][client_city]" => "%{[flow][dst_city]}" }
               }
             }
             if [flow][dst_country] {


### PR DESCRIPTION
For some reason, Logstash 6.7.x didn't throw a shitfit over this, but 7.0.0 certainly does. Error below.

```
[2019-04-24T12:14:03,591][ERROR][logstash.filters.dns ] DNS: Unexpected Error. \{:field=>"[node][hostname]", :value=>"x.x.x.x", :message=>"stream has already been operated upon or closed"}
[2019-04-24T12:16:02,693][ERROR][org.logstash.execution.WorkerLoop] Exception in pipelineworker, the pipeline stopped processing new events, please check your filter configuration and restart Logstash.
org.jruby.exceptions.RuntimeError: (RuntimeError) Invalid FieldReference: `[flow][server_city]]`
 at org.logstash.ext.JrubyEventExtLibrary$RubyEvent.include?(org/logstash/ext/JrubyEventExtLibrary.java:127) ~[logstash-core.jar:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.util.decorators.add_fields(/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:19) ~[?:?]
 at org.jruby.RubyArray.each(org/jruby/RubyArray.java:1792) ~[jruby-complete-9.2.6.0.jar:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.util.decorators.add_fields(/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:17) ~[?:?]
 at org.jruby.RubyHash.each(org/jruby/RubyHash.java:1419) ~[jruby-complete-9.2.6.0.jar:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.util.decorators.add_fields(/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:14) ~[?:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.filter_matched(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:182) ~[?:?]
 at usr.share.logstash.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_filter_minus_mutate_minus_3_dot_4_dot_0.lib.logstash.filters.mutate.filter(/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-filter-mutate-3.4.0/lib/logstash/filters/mutate.rb:264) ~[?:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.do_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:143) ~[?:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.multi_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:162) ~[?:?]
 at org.jruby.RubyArray.each(org/jruby/RubyArray.java:1792) ~[jruby-complete-9.2.6.0.jar:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.multi_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:159) ~[?:?]
 at org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.multi_filter(org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:115) ~[logstash-core.jar:?]
 at usr.share.logstash.logstash_minus_core.lib.logstash.java_pipeline.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:235) ~[?:?]
[2019-04-24T12:16:02,826][FATAL][logstash.runner ] An unexpected error occurred! \{:error=>java.lang.IllegalStateException: org.jruby.exceptions.RuntimeError: (RuntimeError) Invalid FieldReference: `[flow][server_city]]`, :backtrace=>["org.logstash.execution.WorkerLoop.run(org/logstash/execution/WorkerLoop.java:85)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:440)", "org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:304)", "usr.share.logstash.logstash_minus_core.lib.logstash.java_pipeline.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:235)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:286)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:270)", "java.lang.Thread.run(java/lang/Thread.java:748)"]}
[2019-04-24T12:16:03,054][ERROR][org.logstash.Logstash ] java.lang.IllegalStateException: Logstash stopped processing because of an error: (SystemExit) exit
```