### PR TITLE
Fixes #306 - Removes extra closing square brackets

### DIFF
--- a/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_90_post_process.logstash.conf
@@ -736,7 +736,7 @@ filter {
             if [flow][src_city] {
               mutate {
                 id => "elastiflow_postproc_dstIsSrv_add_src_src_city"
-                add_field => { "[flow][client_city]]" => "%{[flow][src_city]}" }
+                add_field => { "[flow][client_city]" => "%{[flow][src_city]}" }
               }
             }
             if [flow][src_country] {
@@ -793,7 +793,7 @@ filter {
             if [flow][dst_city] {
               mutate {
                 id => "elastiflow_postproc_srcIsSrv_add_dst_city"
-                add_field => { "[flow][client_city]]" => "%{[flow][dst_city]}" }
+                add_field => { "[flow][client_city]" => "%{[flow][dst_city]}" }
               }
             }
             if [flow][dst_country] {


### PR DESCRIPTION
Removed extra closing square brackets from:

```
739:                add_field => { "[flow][client_city]" => "%{[flow][src_city]}" }
796:                 add_field => { "[flow][client_city]" => "%{[flow][dst_city]}" }
```