### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     depends_on:
       - elastiflow-elasticsearch-oss
     network_mode: host
+    extra_hosts:
+      - "elasticsearch:127.0.0.1"
     environment:
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: 5601
@@ -66,7 +68,7 @@ services:
       LOGGING_QUIET: 'true'
 
   elastiflow-logstash-oss:
-    image: robcowart/elastiflow-logstash-oss:3.5.0_6.1.3
+    image: robcowart/elastiflow-logstash-oss:3.5.0_7.0.1
     container_name: elastiflow-logstash-oss
     restart: 'no'
     depends_on:


### PR DESCRIPTION
Resolved issues with version mismatch of elastiflow-logstash-oss
Added elasticsearch:127.0.0.1 to host file of elastiflow-kibana-oss as it seems to be hard-coded to use http://elasticsearch:9200 irrespective of the environmental variable set