### PR TITLE
fix: uses ELASTICSEARCH_HOSTS instead of ELASTICSEARCH_URL after Kiba…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: 5601
 
-      ELASTICSEARCH_URL: "http://127.0.0.1:9200"
+      ELASTICSEARCH_HOSTS: "http://127.0.0.1:9200"
 
       KIBANA_DEFAULTAPPID: "dashboard/653cf1e0-2fd2-11e7-99ed-49759aed30f5"
 


### PR DESCRIPTION
Kibana 7.0 doesn't look ELASTICSEARCH_URL.
Please use ELASTICSEARCH_HOSTS instead of ELASTICSEARCH_URL after Kibana 6.6

Please see:

https://www.elastic.co/guide/en/kibana/current/docker.html
https://www.elastic.co/guide/en/kibana/7.0/docker.html
https://www.elastic.co/guide/en/kibana/6.6/docker.html
https://www.elastic.co/guide/en/kibana/6.5/docker.html