### PR TITLE
For sflow expanded_flow_samples, use different source for (input|output)_snmp

### DIFF
--- a/logstash/elastiflow/conf.d/20_filter_40_sflow.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_40_sflow.logstash.conf
@@ -97,7 +97,7 @@ filter {
           "frame_length_times_sampling_rate" => "[flow][bytes]"
           "input_interface" => "[flow][input_snmp]"
           "input_interface_format" => "[sflow][input_interface_format]"
-          "input_interface_value" => "[sflow][input_interface_value]"
+          "input_interface_value" => "[flow][input_snmp]"
           "ip_address_next_hop_router" => "[flow][next_hop]"
           "ip_dscp" => "[sflow][ip_dscp]"
           "ip_ecn" => "[sflow][ip_ecn]"
@@ -112,7 +112,7 @@ filter {
           "ip_version" => "[flow][ip_version]"
           "output_interface" => "[flow][output_snmp]"
           "output_interface_format" => "[sflow][output_interface_format]"
-          "output_interface_value" => "[sflow][output_interface_value]"
+          "output_interface_value" => "[flow][output_snmp]"
           "packet_length" => "[sflow][packet_length]"
           "protocol" => "[sflow][protocol]"
           "sample_length" => "[sflow][sample_length]"
@@ -170,7 +170,7 @@ filter {
           refresh_behaviour => "replace"
         }
       }
-      
+
       # Populate normalized ElastiFlow fields with simple mapping from sFlow flow sample.
       mutate {
         id => "sflow_simple_mappings"


### PR DESCRIPTION
For sflow expanded_flow_sample records, input_interface/output_interface is not defined and as such flow.(input|output)_snmp is not populated. Since both the Kibana dashboards and the if_name functionality expect the interface index in that field, sflow sources which send expanded_flow_samples currently do have suboptimal usability out of the box.

This PR does a simple rename so these things work.

This is a backwards-incompatible change. If somebody is using the [sflow][X_interface_value]-fields, that will stop working. It may be better to copy the field, though I'm not really in a position to judge whether that is necessary :)

(noticed this when getting sflow data from Huawei VRP switches (namely the S5700-SI-series)).