### PR TITLE
Support overriding the sampling interval for IPFIX flows.

### DIFF
--- a/logstash/elastiflow/conf.d/20_filter_30_ipfix.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_30_ipfix.logstash.conf
@@ -387,6 +387,19 @@ filter {
       }
     
     # If sampled IPFIX, adjust Bytes and Packets accordingly.
+      # Workaround for sampled flows when the sampling interval is not set
+      if ![flow][sampling_interval] {
+        translate {
+          dictionary_path => "${ELASTIFLOW_DICT_PATH:/etc/logstash/elastiflow/dictionaries}/sampling_interval.yml"
+          field => "[node][ipaddr]"
+          destination => "[flow][sampling_interval]"
+          fallback => "0"
+          refresh_behaviour => "replace"
+        }
+        mutate {
+          convert => { "[flow][sampling_interval]" => "integer" }
+        }
+      }
       if [flow][sampling_interval] {
         if [flow][bytes] and [flow][sampling_interval] > 0 {
           ruby {


### PR DESCRIPTION
Not all IPFIX exporters are sending sampling interval information along with the flow records.
In my environment, I'm sending some IPFIX flows from Juniper MX routers which don't have the sampling rate in the "Data" flowsets, but instead in the "Options" flowset. It seems like the netflow/ipfix logstash input may need to be extended to support this.

The existing logstash filtering configuration seems to only support overriding the sampling interval from a dictionary for netflow records.

This change ports that same functionality to the IPFIX filter config.