### PR TITLE
Fix #504

### DIFF
--- a/logstash/elastiflow/conf.d/20_filter_20_netflow.logstash.conf
+++ b/logstash/elastiflow/conf.d/20_filter_20_netflow.logstash.conf
@@ -759,12 +759,13 @@ filter {
 
     # If sampled Netflow, adjust Bytes and Packets accordingly.
       # Workaround for sampled flows when the sampling interval is not set (e.g. from Cisco IOS XR or some Huawei devices)
-      if ![flow][sampling_interval] {
+      if ![flow][sampling_interval] or [flow][sampling_interval] == 0 or [flow][sampling_interval] == "0" {
         translate {
           dictionary_path => "${ELASTIFLOW_DICT_PATH:/etc/logstash/elastiflow/dictionaries}/sampling_interval.yml"
           field => "[node][ipaddr]"
           destination => "[flow][sampling_interval]"
           fallback => "0"
+          override => true
           refresh_behaviour => "replace"
         }
         mutate {


### PR DESCRIPTION
The translate filter was changed to handle case when the sampling_interval is present, but set to 0.
In that case, the existing filter would not overwrite the value with the one from the dictionary.