### PR TITLE
Update 87-elastiflow.conf

### DIFF
--- a/sysctl.d/87-elastiflow.conf
+++ b/sysctl.d/87-elastiflow.conf
@@ -19,6 +19,6 @@
 net.core.somaxconn=2048
 net.core.netdev_max_backlog=8192
 net.core.rmem_max=33554432
-net.core.rmem_default=262144
+net.core.rmem_default=26214400
 net.ipv4.udp_rmem_min=131072
 net.ipv4.udp_mem=2097152 4194304 8388608


### PR DESCRIPTION
"net.core.rmem_default/2" is the logstash-input-udp default "receive_buffer_bytes" size.
The default 128k is too small.