### PR TITLE
Add support for specifying cacert in env vars

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -252,10 +252,11 @@ ELASTIFLOW_ES_USER | The username for the connection to Elasticsearch | elastic
 ELASTIFLOW_ES_PASSWD | The password for the connection to Elasticsearch | changeme
 ELASTIFLOW_ES_SSL_ENABLE | Enable or disable SSL connection to Elasticsearch | false
 ELASTIFLOW_ES_SSL_VERIFY | Enable or disable verification of the SSL certificate. If enabled, the output must be edited to set the path to the certificate. | false
+ELASTIFLOW_ES_SSL_CACERT | Path to CA certificate | /etc/ssl/certs/ca-bundle.crt
 
 > If you are only using the open-source version of Elasticsearch, it will ignore the username and password. In that case just leave the defaults.
 
-> If `ELASTIFLOW_ES_SSL_ENABLE` and `ELASTIFLOW_ES_SSL_VERIFY` are both `true`, you must uncomment the `cacert` option in the Elasticsearch output and set the path to the certificate.
+> If `ELASTIFLOW_ES_SSL_ENABLE` and `ELASTIFLOW_ES_SSL_VERIFY` are both `true`, you must set the `ELASTIFLOW_ES_SSL_CACERT` option with the path to the certificate or CA certificate.
 
 ### 10. Enable DNS name resolution (optional)
 
@@ -394,6 +395,7 @@ ELASTIFLOW_ES_HOST_2 | The second Elasticsearch host to which the output will se
 ELASTIFLOW_ES_HOST_3 | The third Elasticsearch host to which the output will send data | 127.0.0.3:9200
 ELASTIFLOW_ES_SSL_ENABLE | Enable or disable SSL connection to Elasticsearch | false
 ELASTIFLOW_ES_SSL_VERIFY | Enable or disable verification of the SSL certificate. If enabled, the output must be edited to set the path to the certificate. | false
+ELASTIFLOW_ES_SSL_CACERT | Path to CA certificate | /etc/ssl/certs/ca-bundle.crt
 ELASTIFLOW_ES_USER | The username for the connection to Elasticsearch | elastic
 ELASTIFLOW_ES_PASSWD | The password for the connection to Elasticsearch | changeme
 ELASTIFLOW_NETFLOW_IPV4_HOST | The IPv4 address on which to listen for Netflow messages | 0.0.0.0

--- a/logstash.service.d/elastiflow.conf
+++ b/logstash.service.d/elastiflow.conf
@@ -57,6 +57,7 @@ Environment="ELASTIFLOW_ES_HOST_3=127.0.0.3:9200"
 # If ELASTIFLOW_ES_SSL_VERIFY is true then you must edit the output and set the path where the cacert can be found.
 Environment="ELASTIFLOW_ES_SSL_ENABLE=false"
 Environment="ELASTIFLOW_ES_SSL_VERIFY=false"
+Environment="ELASTIFLOW_ES_SSL_CACERT=/etc/ssl/certs/ca-bundle.crt"
 
 
 # Netflow - IPv4

--- a/logstash/elastiflow/conf.d/30_output_10_single.logstash.conf
+++ b/logstash/elastiflow/conf.d/30_output_10_single.logstash.conf
@@ -21,7 +21,7 @@ output {
     ssl => "${ELASTIFLOW_ES_SSL_ENABLE:false}"
     ssl_certificate_verification => "${ELASTIFLOW_ES_SSL_VERIFY:false}"
     # If ssl_certificate_verification is true, uncomment cacert and set the path to the certificate.
-    #cacert => "/PATH/TO/CERT"
+    cacert => "${ELASTIFLOW_ES_SSL_CACERT:/etc/ssl/certs/ca-bundle.crt}"
     user => "${ELASTIFLOW_ES_USER:elastic}"
     password => "${ELASTIFLOW_ES_PASSWD:changeme}"
     index => "elastiflow-4.0.1-%{+YYYY.MM.dd}"

--- a/logstash/elastiflow/conf.d/30_output_20_multi.logstash.conf.disabled
+++ b/logstash/elastiflow/conf.d/30_output_20_multi.logstash.conf.disabled
@@ -21,7 +21,7 @@ output {
     ssl => "${ELASTIFLOW_ES_SSL_ENABLE:false}"
     ssl_certificate_verification => "${ELASTIFLOW_ES_SSL_VERIFY:false}"
     # If ssl_certificate_verification is true, uncomment cacert and set the path to the certificate.
-    #cacert => "/PATH/TO/CERT"
+    cacert => "${ELASTIFLOW_ES_SSL_CACERT:/etc/ssl/certs/ca-bundle.crt}"
     user => "${ELASTIFLOW_ES_USER:elastic}"
     password => "${ELASTIFLOW_ES_PASSWD:changeme}"
     index => "elastiflow-4.0.1-%{+YYYY.MM.dd}"

--- a/profile.d/elastiflow.sh
+++ b/profile.d/elastiflow.sh
@@ -55,6 +55,7 @@ export ELASTIFLOW_ES_HOST_3=127.0.0.3:9200
 # If ELASTIFLOW_ES_SSL_VERIFY is true then you must edit the output and set the path where the cacert can be found.
 export ELASTIFLOW_ES_SSL_ENABLE=false
 export ELASTIFLOW_ES_SSL_VERIFY=false
+export ELASTIFLOW_ES_SSL_CACERT=/etc/ssl/certs/ca-bundle.crt
 
 
 # Netflow - IPv4


### PR DESCRIPTION
This adds support for specifying the `cacert` value in Elasticsearch output. In a long-running issue, Logstash ES output will not work with `ssl => true, ssl_certificate_verification => false` without the `cacert` being set. See this 4 year old (and still active) issue for details: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/433

This PR should let those running elastiflow in an ephemeral container more easily configure the `cacert` value.